### PR TITLE
feat: update ECC and BOA apps

### DIFF
--- a/src/constants/external.ts
+++ b/src/constants/external.ts
@@ -27,10 +27,10 @@ export const ED_APP_LINK =
 export const DC_APP_LINK =
   'https://drive.google.com/file/d/1jIdKeR302mdhik5IXZQzZiZIdCokWU6X/view'
 export const BOA_APP_LINK =
-  'https://drive.google.com/file/d/1wB78uCwHvlT8625-AMysVsJiFx1AAsLC/view'
+  'https://docs.google.com/document/d/13n_my0_yWnj5aw1JBQV59s7Lm2kI5gT3'
 
 export const ECC_APP_LINK =
-  'https://firebasestorage.googleapis.com/v0/b/maasu-master.appspot.com/o/Applications%2F2023-2024%20Executive%20Coordinating%20Committee%20Application%20Descriptions%20-%20Google%20Docs%20-%20Google%20Docs.pdf?alt=media&token=22e82de5-56fe-4fa1-ad7e-8b29ba626aa2'
+  'https://docs.google.com/document/d/1Q505E72o6IlE59YreIs1Wl1sSXCWosYD3Yht8oDwuUw'
 
 // -----------------------------------------------------
 // Donate

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -141,30 +141,30 @@ Directors Council applications are currently closed.
 export const DC_APP_STATUS = DC_APP_STATUS_CLOSED
 
 // BOA
-export const BOA_APP_ISOPEN = false
+export const BOA_APP_ISOPEN = true
 
 export const BOA_APP_STATUS_OPEN = `
-Board of Advisors applications are currently open!
+Board of Advisors applications are currently open! Applications close on November 28th at 11:59 CST.
 `
 
 export const BOA_APP_STATUS_CLOSED = `
 Board of Advisors applications are currently closed.
 `
 
-export const BOA_APP_STATUS = BOA_APP_STATUS_CLOSED
+export const BOA_APP_STATUS = BOA_APP_STATUS_OPEN
 
 // ECC
-export const ECC_APP_ISOPEN = false
+export const ECC_APP_ISOPEN = true
 
 export const ECC_APP_STATUS_OPEN = `
-Executive Coordinating Committee applications are currently open!
+Executive Coordinating Committee applications are currently open! Applications close on November 28th at 11:59 CST.
 `
 
 export const ECC_APP_STATUS_CLOSED = `
 Executive Coordinating Committee applications are currently closed.
 `
 
-export const ECC_APP_STATUS = ECC_APP_STATUS_CLOSED
+export const ECC_APP_STATUS = ECC_APP_STATUS_OPEN
 
 // -----------------------------------------------------
 // Members


### PR DESCRIPTION
| Conference Year | Conference Name |
| --- | --- |
| 2023 | Ad Astra |

### Major Changes
- updated ECC and BOA apps
